### PR TITLE
Migrate from texi2html to texi2any

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -50,7 +50,7 @@ doc: flite.html flite.pdf
 flite.html: flite.texi
 	@ if [ ! -d html ] ; \
           then mkdir -p html ; fi
-	(cd html; texi2html -number -split_chapter ../flite.texi)
+	(cd html; texi2any --set-customization-variable TEXI2HTML=1  --split=chapter ../flite.texi)
 	@ if [ -d html/flite ] ; \
 	  then mv html/flite/*.html html ; \
                rmdir html/flite; fi


### PR DESCRIPTION
The texi2html utility ceased being developed upstream in 2011, and upstream has
declared it superseded by the texi2any utility from texinfo.