### PR TITLE
Fix win64 compilation/execution

### DIFF
--- a/src/audio/au_win.c
+++ b/src/audio/au_win.c
@@ -58,7 +58,7 @@ typedef struct au_win_pdata_struct {
   int fqmaxlen;
 } au_win_pdata;
 
-void add_to_free_queue(cst_audiodev *ad, void *datum)
+static void add_to_free_queue(cst_audiodev *ad, void *datum)
 {
     au_win_pdata *pd = ad->platform_data;
 
@@ -87,8 +87,8 @@ static void finish_header(HWAVEOUT drvr, WAVEHDR *hdr)
     cst_free(hdr);
 }
 
-void CALLBACK sndbuf_done(HWAVEOUT drvr, UINT msg,
-			  DWORD udata, DWORD param1, DWORD param2)
+static void CALLBACK sndbuf_done(HWAVEOUT drvr, UINT msg,
+			  DWORD_PTR udata, DWORD_PTR param1, DWORD_PTR param2)
 {
     WAVEHDR *hdr = (WAVEHDR *)param1;
     cst_audiodev *ad = (cst_audiodev *)udata;
@@ -141,7 +141,7 @@ cst_audiodev *audio_open_win(int sps, int channels, int fmt)
     wfx.nBlockAlign = wfx.nChannels*wfx.wBitsPerSample/8;
     wfx.nAvgBytesPerSec = wfx.nSamplesPerSec*wfx.nBlockAlign;
     err = waveOutOpen(&wo,WAVE_MAPPER,&wfx,
-                      (DWORD)sndbuf_done,(DWORD)ad,
+                      (DWORD_PTR)sndbuf_done,(DWORD_PTR)ad,
                       CALLBACK_FUNCTION);
     if (err != MMSYSERR_NOERROR)
     {

--- a/src/audio/au_wince.c
+++ b/src/audio/au_wince.c
@@ -54,7 +54,7 @@ typedef struct au_wince_pdata_struct {
   int fqmaxlen;
 } au_wince_pdata;
 
-void add_to_free_queue(cst_audiodev *ad, void *datum)
+static void add_to_free_queue(cst_audiodev *ad, void *datum)
 {
     au_wince_pdata *pd = ad->platform_data;
 
@@ -83,7 +83,7 @@ static void finish_header(HWAVEOUT drvr, WAVEHDR *hdr)
     cst_free(hdr);
 }
 
-void CALLBACK sndbuf_done(HWAVEOUT drvr, UINT msg,
+static void CALLBACK sndbuf_done(HWAVEOUT drvr, UINT msg,
 			  DWORD udata, DWORD param1, DWORD param2)
 {
     WAVEHDR *hdr = (WAVEHDR *)param1;


### PR DESCRIPTION
Fix compilation on windows by making functions static
Fix win64 execution by using correct size types

I noticed these issues while trying to get flite working in MSVC 2015, but they are core issues that could also cause problems in gcc so I wanted to push the fixes up