### PR TITLE
* SSML: Ability to pass pitch and range prosody attributes

### DIFF
--- a/src/cg/cst_cg.c
+++ b/src/cg/cst_cg.c
@@ -443,15 +443,15 @@ static void cg_smooth_F0(cst_utterance *utt,
     /* Smooth F0 and mark unvoice frames as 0.0 */
     cst_item *mcep;
     int i;
-    float mean, stddev;
+    float base_mean, base_stddev;
 
     /* cg_smooth_F0_naive(param_track); */
     
     cg_F0_interpolate_spline(utt,param_track);
 
-    mean = get_param_float(utt->features,"int_f0_target_mean", cg_db->f0_mean);
-    mean *= get_param_float(utt->features,"f0_shift", 1.0);
-    stddev = 
+    base_mean = get_param_float(utt->features,"int_f0_target_mean", cg_db->f0_mean);
+    base_mean *= get_param_float(utt->features,"f0_shift", 1.0);
+    base_stddev =
         get_param_float(utt->features,"int_f0_target_stddev", cg_db->f0_stddev);
 #if 0
     FILE *ftt; int ii;
@@ -467,6 +467,25 @@ static void cg_smooth_F0(cst_utterance *utt,
     {
         if (voiced_frame(mcep))
         {
+            float mean = base_mean;
+            float stddev = base_stddev;
+            float local_f0_mean =
+            ffeature_float(mcep,
+                "R:mcep_link.parent.R:segstate.parent.R:SylStructure.parent.parent.R:Token.parent.local_f0_mean"
+            );
+            if (local_f0_mean != 0.0)
+            {
+                mean = local_f0_mean;
+            }
+            float local_f0_range =
+            ffeature_float(mcep,
+                "R:mcep_link.parent.R:segstate.parent.R:SylStructure.parent.parent.R:Token.parent.local_f0_range"
+            );
+            if (local_f0_range > 0.0)
+            {
+                /* feature_float returns 0 by default, shifted to allow 0 to be passed. */
+                stddev = local_f0_range - 1.0;
+            }
             /* scale the F0 -- which normally wont change it at all */
             param_track->frames[i][0] = 
                 (((param_track->frames[i][0]-cg_db->f0_mean)/cg_db->f0_stddev) 


### PR DESCRIPTION
Pass pitch and range as attributes of the prosody element.

Units are Hertz (as specified by the [W3C document](https://www.w3.org/TR/speech-synthesis11/#edef_prosody)).

```xml
<prosody range='6'><prosody rate='.25' pitch='174'>Amazing
<prosody rate='.5' pitch='220'>grace,<break/>

<prosody rate='.35' pitch='196'>how
<prosody pitch='174'>  sweet
<prosody pitch='147'>the
<prosody pitch='131'>sound,<break/>

<prosody rate='.35' pitch='131'>that
<prosody pitch='174'>saved
<prosody pitch='220'>a wretch
<prosody rate='.25' pitch='196'> like
<prosody rate='.15' pitch='262'>me!<break/>
```

`bin/flite -voice awb -ssml grace.ssml -o singing.wav`

This doesn't work with all of the voices(?)