### PR TITLE
Fix Mingw32 compilation

### DIFF
--- a/configure
+++ b/configure
@@ -4080,11 +4080,17 @@ case "$target_os" in
                 # For the Windows under mingw32 environment
                 # http://www.mingw.org
 		shared=false
-     	        CFLAGS="$CFLAGS -DCST_NO_SOCKETS -DUNDER_WINDOWS -DWIN32 -shared"
-                MINGWPREF="i386-mingw32-"
-                CC="${MINGWPREF}gcc"
-                RANLIB="${MINGWPREF}ranlib"
-                AR="${MINGWPREF}ar"
+     	        CFLAGS="$CFLAGS -DCST_NO_SOCKETS -DUNDER_WINDOWS -DWIN32"
+                PREFLEN=`expr match "$CC" ".*-gcc"`
+                if expr $PREFLEN != 0 > /dev/null; then
+                    # When $CC includes "-gcc", use the preceding
+                    # charactors + '-' as MINGPREF.
+                    # for example:
+                    #   CC=x86_64-w64-mingw32-gcc.exe
+                    #   --> MINGWPREF=x86_64-w64-mingw32-
+                    PREFLEN=`expr $PREFLEN - 3`
+                    MINGPREF=`expr substr $CC 1 $PREFLEN`
+                fi
                 WINDRES="${MINGWPREF}windres"
                 DLLTOOL="${MINGWPREF}dlltool"
                 DLLWRAP="${MINGWPREF}dllwrap"
@@ -4355,7 +4361,8 @@ if test "x$ac_cv_header_alsa_asoundlib_h" = xyes; then :
 fi
 
 
-ac_fn_c_check_header_mongrel "$LINENO" "mmsystem.h" "ac_cv_header_mmsystem_h" "$ac_includes_default"
+ac_fn_c_check_header_compile "$LINENO" "mmsystem.h" "ac_cv_header_mmsystem_h" "#include <windows.h>
+"
 if test "x$ac_cv_header_mmsystem_h" = xyes; then :
   AUDIODRIVER="wince"
 	       AUDIODEFS=-DCST_AUDIO_WINCE
@@ -4368,11 +4375,6 @@ case "$target_os" in
      wince*)
         AUDIODRIVER="wince"
         AUDIODEFS=-DCST_AUDIO_WINCE
-        AUDIOLIBS=
-     ;;
-     mingw*)
-        AUDIODRIVER="none"
-        AUDIODEFS=-DCST_AUDIO_NONE
         AUDIOLIBS=
      ;;
      android*)

--- a/configure.in
+++ b/configure.in
@@ -136,11 +136,17 @@ dnl         ;;
                 # For the Windows under mingw32 environment
                 # http://www.mingw.org
 		shared=false
-     	        CFLAGS="$CFLAGS -DCST_NO_SOCKETS -DUNDER_WINDOWS -DWIN32 -shared"
-                MINGWPREF="i386-mingw32-"
-                CC="${MINGWPREF}gcc"
-                RANLIB="${MINGWPREF}ranlib"
-                AR="${MINGWPREF}ar"
+     	        CFLAGS="$CFLAGS -DCST_NO_SOCKETS -DUNDER_WINDOWS -DWIN32"
+                PREFLEN=`expr match "$CC" ".*-gcc"`
+                if expr $PREFLEN != 0 > /dev/null; then
+                    # When $CC includes "-gcc", use the preceding
+                    # charactors + '-' as MINGPREF.
+                    # for example:
+                    #   CC=x86_64-w64-mingw32-gcc.exe
+                    #   --> MINGWPREF=x86_64-w64-mingw32-
+                    PREFLEN=`expr $PREFLEN - 3`
+                    MINGPREF=`expr substr $CC 1 $PREFLEN`
+                fi
                 WINDRES="${MINGWPREF}windres"
                 DLLTOOL="${MINGWPREF}dlltool"
                 DLLWRAP="${MINGWPREF}dllwrap"
@@ -387,18 +393,15 @@ AC_CHECK_HEADER(alsa/asoundlib.h,
 AC_CHECK_HEADER(mmsystem.h,
 	      [AUDIODRIVER="wince"
 	       AUDIODEFS=-DCST_AUDIO_WINCE
-	       AUDIOLIBS=-lwinmm])
+	       AUDIOLIBS=-lwinmm],
+	      [],
+	      [#include <windows.h>])
 
 dnl I don't care what you ask for, for wince you get wince
 case "$target_os" in
      wince*)
         AUDIODRIVER="wince"
         AUDIODEFS=-DCST_AUDIO_WINCE
-        AUDIOLIBS=
-     ;;
-     mingw*)
-        AUDIODRIVER="none"
-        AUDIODEFS=-DCST_AUDIO_NONE
         AUDIOLIBS=
      ;;
      android*)

--- a/include/cst_file.h
+++ b/include/cst_file.h
@@ -101,7 +101,13 @@ int cst_sprintf(char *s, const char *fmt, ...);
 #ifdef _WIN32
 #define snprintf c99_snprintf
 
-__inline int c99_vsnprintf(char* str, size_t size, const char* format,
+#ifdef __GNUC__
+#define INLINE static inline
+#else
+#define INLINE __inline
+#endif
+
+INLINE int c99_vsnprintf(char* str, size_t size, const char* format,
 va_list ap)  {
        int count = -1;
        if (size != 0)
@@ -110,7 +116,7 @@ va_list ap)  {
            count = _vscprintf(format, ap);
        return count;
    }
-__inline int c99_snprintf(char* str, size_t size, const char* format, ...)
+INLINE int c99_snprintf(char* str, size_t size, const char* format, ...)
 {
        int count;
        va_list ap;

--- a/include/cst_tokenstream.h
+++ b/include/cst_tokenstream.h
@@ -130,7 +130,7 @@ cst_tokenstream *ts_open_generic(const char *filename,
                                  int (*getc)(cst_tokenstream *ts));
 void ts_close(cst_tokenstream *ts);
 
-#ifdef _WIN32
+#if defined(_WIN32) && !defined(__GNUC__)
 __inline int ts_utf8_sequence_length(char c0);
 #else
 int ts_utf8_sequence_length(char c0);

--- a/src/audio/au_wince.c
+++ b/src/audio/au_wince.c
@@ -43,6 +43,10 @@
 #include "cst_audio.h"
 #include "cst_alloc.h"
 
+#ifndef MAXULONG_PTR
+#define DWORD_PTR DWORD
+#endif
+
 typedef struct au_wince_pdata_struct {
 	HWAVEOUT wo;
 	HANDLE bevt;
@@ -84,7 +88,7 @@ static void finish_header(HWAVEOUT drvr, WAVEHDR *hdr)
 }
 
 static void CALLBACK sndbuf_done(HWAVEOUT drvr, UINT msg,
-			  DWORD udata, DWORD param1, DWORD param2)
+			  DWORD_PTR udata, DWORD_PTR param1, DWORD_PTR param2)
 {
     WAVEHDR *hdr = (WAVEHDR *)param1;
     cst_audiodev *ad = (cst_audiodev *)udata;
@@ -137,7 +141,7 @@ cst_audiodev *audio_open_wince(int sps, int channels, int fmt)
     wfx.nBlockAlign = wfx.nChannels*wfx.wBitsPerSample/8;
     wfx.nAvgBytesPerSec = wfx.nSamplesPerSec*wfx.nBlockAlign;
     err = waveOutOpen(&wo,WAVE_MAPPER,&wfx,
-                      (DWORD)sndbuf_done,(DWORD)ad,
+                      (DWORD_PTR)sndbuf_done,(DWORD_PTR)ad,
                       CALLBACK_FUNCTION);
     if (err != MMSYSERR_NOERROR)
     {

--- a/src/utils/cst_tokenstream.c
+++ b/src/utils/cst_tokenstream.c
@@ -266,7 +266,7 @@ static void get_token_sub_part(cst_tokenstream *ts,
     (*buffer)[p] = '\0';
 }
 
- #ifdef _WIN32
+ #if defined _WIN32 && !defined(__GNUC__)
  __inline int ts_utf8_sequence_length(char c0)
  #else
  int ts_utf8_sequence_length(char c0)

--- a/windows/Makefile
+++ b/windows/Makefile
@@ -40,7 +40,7 @@
 ##  Also an example command line program                                 ## 
 ##                                                                       ##
 ##  At top level                                                         ##
-##      ./configure --target=i386-mingw32                                ##
+##      ./configure                                                      ##
 ##      make                                                             ##
 ##                                                                       ##
 ###########################################################################


### PR DESCRIPTION
I fixed flite compilation using mingw32 gcc, bundled with [rubyinstaller](https://rubyinstaller.org/downloads/).
This PR includes three commits:

1.  Fix configure when using mingw32 gcc.
    1. Set MINGWPREF by checking the CC variable value.
    2. Include windows.h when checking mmsystem.h header.
    3. Use wince audio driver when mmsystem.h is available.
2. Fix undefined reference to c99_vsnprintf and ts_utf8_sequence_length when using mingw32 gcc.
    The mingw32 gcc compiler doesn't treat __inline as Visual C++ does.
    Use `static inline` instead of `__inline` for c99_vsnprintf.
    Don't use `__inline` for ts_utf8_sequence_length.

3. Use DWORD_PTR instead of DWORD when DWORD_PTR is available in au_wince.c.

The generated 64-bit `flite.exe` works well on Windows 10.
