### PR TITLE
Add method to override memory operations for an application

### DIFF
--- a/src/utils/cst_alloc.c
+++ b/src/utils/cst_alloc.c
@@ -64,6 +64,8 @@ void *cst_alloc_cunks[NUM_CHUNKS];
 #endif
 #endif
 
+#ifndef CST_USER_MALLOC	/* Define to override cst_safe_alloc, cst_safe_calloc, cst_safe_realloc, cst_free */
+
 void *cst_safe_alloc(int size)
 {
     /* returns pointer to memory all set 0 */
@@ -185,6 +187,8 @@ void cst_free(void *p)
 #endif
     }
 }
+
+#endif
 
 #ifdef CST_DEBUG_MALLOC_TRACE
 


### PR DESCRIPTION
For game consoles, and often game engines in general, we don't allow use of global malloc/free.  This allows us to very carefully manage our memory usage for both efficiency, in terms of performance and memory layout, and stability.

This change just adds a define that, if defined, removes the definition of the cst_ allocation functions.  This forces the user to define their own versions.

I also looked at quite simply removing the call to malloc and replacing that with a define as follows:

`#ifndef CST_USER_MALLOC`
`#define CST_LLMALLOC(x) malloc(x)`
`#endif`

I went against that since it requires considerably more code changes and the maintenance would be more difficult when looking at the number of platforms flite supports. 

With the higher level change I made, we can simply override it for the platforms we care about and leave it as is for others.

Ideally, a compromise would be to create a sort of cst_allocator, but that gets more complicated and I feel would bloat the flite system.