### PR TITLE
Cross-compile for wasm32-wasi target

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,8 @@ We have successfully compiled and run on
 
     o OSF1 V4.0 (gives an unimportant warning about sizes when compiled cst_val.c)
 
+    o WASI has experimental support (see below for details)
+
 Previously we supported PalmOS and Windows CE but these seem to be rare
 nowadays so they are no longer actively supported.
 
@@ -133,6 +135,47 @@ architectures may not work directly as there is some careful
 byte order constraints in some structures.  These are portable but may
 require reordering of some fields, contact us if you are moving to
 a new archiecture.
+
+### Cross-compiling to WASI (experimental)
+In order to successfully cross-compile to WASI, firstly head over to
+[CraneStation/wasi-sdk](https://github.com/CraneStation/wasi-sdk)
+and install the WASI toolchain.
+
+Afterwards, you can cross-compile to WASI as follows:
+
+```
+./configure --host=wasm32-wasi \
+CC=/path/to/wasi-sdk/bin/clang \
+AR=/path/to/wasi-sdk/bin/llvm-ar \
+RANLIB=/path/to/wasi-sdk/bin/llvm-ranlib
+```
+
+It is important to correctly specify `ar` and `ranlib` that is bundled
+with the WASI `clang`. Otherwise, you will most likely experience missing
+symbols during linking, plus you may experience weird `llvm` errors such as
+
+```
+LLVM ERROR: malformed uleb128, extends past end
+```
+
+When cross-compiling from macOS, you might have to manually specify the sysroot.
+You can do this by tweaking the `CC` variable as follows:
+
+```
+CC="/path/to/wasi-sdk/bin/clang --sysroot=/path/to/wasi-sdk/share/sysroot"
+```
+
+After the configure step is successful, simply run as usual:
+```
+make
+```
+
+The generated WASI binary can then be found in `bin/` directory:
+
+```
+file bin/flite
+> bin/flite: WebAssembly (wasm) binary module version 0x1 (MVP)
+```
 
 News
 ----

--- a/config.sub
+++ b/config.sub
@@ -127,6 +127,10 @@ case $maybe_os in
     os=-linux-android
     basic_machine=`echo $1 | sed 's/^\(.*\)-\([^-]*-[^-]*\)$/\1/'`-unknown
     ;;
+  wasm32-wasi)
+    echo "wasm32-wasi"
+    exit
+    ;;
   *)
     basic_machine=`echo $1 | sed 's/-[^-]*$//'`
     if [ $basic_machine != $1 ]

--- a/configure
+++ b/configure
@@ -2245,21 +2245,28 @@ fi
 $as_echo "$ac_cv_host" >&6; }
 case $ac_cv_host in
 *-*-*) ;;
+wasm32-wasi) ;;
 *) as_fn_error $? "invalid value of canonical host" "$LINENO" 5;;
 esac
 host=$ac_cv_host
-ac_save_IFS=$IFS; IFS='-'
-set x $ac_cv_host
-shift
-host_cpu=$1
-host_vendor=$2
-shift; shift
-# Remember, the first character of IFS is used to create $*,
-# except with old shells:
-host_os=$*
-IFS=$ac_save_IFS
-case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
 
+if [ $host = "wasm32-wasi" ]; then
+  host_cpu="wasm32"
+  host_vendor=
+  host_os="wasi"
+else
+  ac_save_IFS=$IFS; IFS='-'
+  set x $ac_cv_host
+  shift
+  host_cpu=$1
+  host_vendor=$2
+  shift; shift
+  # Remember, the first character of IFS is used to create $*,
+  # except with old shells:
+  host_os=$*
+  IFS=$ac_save_IFS
+  case $host_os in *\ *) host_os=`echo "$host_os" | sed 's/ /-/g'`;; esac
+fi
 
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking target system type" >&5
 $as_echo_n "checking target system type... " >&6; }
@@ -2278,21 +2285,28 @@ fi
 $as_echo "$ac_cv_target" >&6; }
 case $ac_cv_target in
 *-*-*) ;;
+wasm32-wasi) ;;
 *) as_fn_error $? "invalid value of canonical target" "$LINENO" 5;;
 esac
 target=$ac_cv_target
-ac_save_IFS=$IFS; IFS='-'
-set x $ac_cv_target
-shift
-target_cpu=$1
-target_vendor=$2
-shift; shift
-# Remember, the first character of IFS is used to create $*,
-# except with old shells:
-target_os=$*
-IFS=$ac_save_IFS
-case $target_os in *\ *) target_os=`echo "$target_os" | sed 's/ /-/g'`;; esac
 
+if [ $target = "wasm32-wasi" ]; then
+  target_cpu="wasm32"
+  target_vendor=
+  target_os="wasi"
+else
+  ac_save_IFS=$IFS; IFS='-'
+  set x $ac_cv_target
+  shift
+  target_cpu=$1
+  target_vendor=$2
+  shift; shift
+  # Remember, the first character of IFS is used to create $*,
+  # except with old shells:
+  target_os=$*
+  IFS=$ac_save_IFS
+  case $target_os in *\ *) target_os=`echo "$target_os" | sed 's/ /-/g'`;; esac
+fi
 
 # The aliases save the names the user supplied, while $host etc.
 # will get canonicalized.
@@ -4154,6 +4168,9 @@ case "$target_os" in
 	darwin*)
 		CFLAGS="$CFLAGS -no-cpp-precomp"
 	;;
+  wasi)
+    CFLAGS="$CFLAGS -DDIE_ON_ERROR -DCST_NO_SOCKETS -DWASM32_WASI"
+  ;;
 esac
 
 

--- a/configure.in
+++ b/configure.in
@@ -210,6 +210,9 @@ dnl         ;;
 	darwin*)
 		CFLAGS="$CFLAGS -no-cpp-precomp"
 	;;
+        wasi*)
+		CFLAGS="$CFLAGS -DDIE_ON_ERROR -DCST_NO_SOCKETS -DWASM32_WASI"
+        ;;
 esac
 
 AC_SUBST(TARGET_OS)

--- a/main/flite_main.c
+++ b/main/flite_main.c
@@ -47,7 +47,12 @@
 #include "flite_version.h"
 
 cst_val *flite_set_voice_list(const char *voxdir);
+
+#ifdef WASM32_WASI
+void flite_set_lang_list(void);
+#else
 void *flite_set_lang_list(void);
+#endif
 
 void cst_alloc_debug_summary();
 

--- a/main/flitevox_info_main.c
+++ b/main/flitevox_info_main.c
@@ -46,7 +46,11 @@
 #include "cst_args.h"
 #include "flite.h"
 
+#ifdef WASM32_WASI
+void flite_set_lang_list(void);
+#else
 void *flite_set_lang_list(void);
+#endif
 
 int main(int argc, char **argv)
 {

--- a/src/utils/cst_error.c
+++ b/src/utils/cst_error.c
@@ -91,7 +91,9 @@ int cst_errmsg(const char *fmt, ...)
 }
 #else
 
+#ifndef WASM32_WASI
 jmp_buf *cst_errjmp = 0;
+#endif
 
 int cst_errmsg(const char *fmt, ...)
 {


### PR DESCRIPTION
This commit adds experimental cross-compilation support for
`wasm32-wasi` target. With this commit added, it is now possible
to cross-compile `flite` to [WASI] which then can be run using
any WASI-compatible runtime such as [Wasmtime].

[WASI]: https://wasi.dev
[Wasmtime]: https://wasmtime.dev

This PR closes #24.