### PR TITLE
fix alsa static

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -383,7 +383,10 @@ AC_CHECK_HEADER(sys/audioio.h,
 AC_CHECK_HEADER(alsa/asoundlib.h,
               [AUDIODRIVER="alsa"
 	       AUDIODEFS=-DCST_AUDIO_ALSA
-               AUDIOLIBS=-lasound])
+               AUDIOLIBS=`pkg-config --libs alsa`
+               if test "$shared" = false; then
+                   AUDIOLIBS=`pkg-config --libs --static alsa`
+               fi])
 AC_CHECK_HEADER(mmsystem.h,
 	      [AUDIODRIVER="wince"
 	       AUDIODEFS=-DCST_AUDIO_WINCE


### PR DESCRIPTION
Use pkg-config to determine alsa link flags. This fixes static linking.

Signed-off-by: Baruch Siach <baruch@tkos.co.il>
[Retrieved from:
https://git.buildroot.net/buildroot/tree/package/flite/0002-fix-alsa-static.patch]
Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>