### PR TITLE
Fix detecting 64bit systems

### DIFF
--- a/include/cst_val.h
+++ b/include/cst_val.h
@@ -46,6 +46,8 @@
 #include "cst_alloc.h"
 #include "cst_val_defs.h"
 
+#include <stdint.h>
+
 /* Only CONS can be an even number */
 #define CST_VAL_TYPE_CONS    0
 #define CST_VAL_TYPE_INT     1
@@ -61,10 +63,15 @@ typedef struct  cst_val_cons_struct {
 
 typedef struct  cst_val_atom_struct {
 #ifdef WORDS_BIGENDIAN
+#if UINTPTR_MAX > 0xfffffffful
+    int ref_count;
+    int type;  /* order is here important */
+#else
     short ref_count;
     short type;  /* order is here important */
+#endif
 #else
-#if (defined(__x86_64__) || defined(_M_X64))
+#if UINTPTR_MAX > 0xfffffffful
     int type;  /* order is here important */
     int ref_count;
 #else
@@ -74,7 +81,7 @@ typedef struct  cst_val_atom_struct {
 #endif
     union 
     {
-#if (defined(__x86_64__) || defined(_M_X64))
+#if UINTPTR_MAX > 0xfffffffful
         double fval;
         long long ival;
         void *vval;

--- a/include/cst_val_const.h
+++ b/include/cst_val_const.h
@@ -111,6 +111,8 @@
 
 #include "cst_val_defs.h"
 
+#include <stdint.h>
+
 /* There is built-in int to string conversions here for numbers   */
 /* up to 20, note if you make this bigger you have to hand change */
 /* other things too                                               */
@@ -191,10 +193,15 @@ extern const cst_val val_string_24;
 /* unquestionably doing the wrong thing                                 */
 typedef struct cst_val_atom_struct_float {
 #ifdef WORDS_BIGENDIAN
+#if UINTPTR_MAX > 0xfffffffful
+    int ref_count;
+    int type;  /* order is here important */
+#else
     short ref_count;
     short type;  /* order is here important */
+#endif
 #else
-#if (defined(__x86_64__) || defined(_M_X64))
+#if UINTPTR_MAX > 0xfffffffful
     int type;  /* order is here important */
     int ref_count;
 #else
@@ -202,7 +209,7 @@ typedef struct cst_val_atom_struct_float {
     short ref_count;
 #endif
 #endif
-#if (defined(__x86_64__) || defined(_M_X64))
+#if UINTPTR_MAX > 0xfffffffful
     double fval;
 #else
     float fval;
@@ -211,10 +218,15 @@ typedef struct cst_val_atom_struct_float {
 
 typedef struct cst_val_atom_struct_int {
 #ifdef WORDS_BIGENDIAN
+#if UINTPTR_MAX > 0xfffffffful
+    int ref_count;
+    int type;  /* order is here important (and unintuitive) */
+#else
     short ref_count;
     short type;  /* order is here important (and unintuitive) */
+#endif
 #else
-#if (defined(__x86_64__) || defined(_M_X64))
+#if UINTPTR_MAX > 0xfffffffful
     int type;  /* order is here important */
     int ref_count;
 #else
@@ -222,7 +234,7 @@ typedef struct cst_val_atom_struct_int {
     short ref_count;
 #endif
 #endif
-#if (defined(__x86_64__) || defined(_M_X64))
+#if UINTPTR_MAX > 0xfffffffful
     long long ival;
 #else
     int ival;
@@ -231,10 +243,15 @@ typedef struct cst_val_atom_struct_int {
 
 typedef struct cst_val_atom_struct_void {
 #ifdef WORDS_BIGENDIAN
+#if UINTPTR_MAX > 0xfffffffful
+    int ref_count;
+    int type;  /* order is here important */
+#else
     short ref_count;
     short type;  /* order is here important */
+#endif
 #else
-#if (defined(__x86_64__) || defined(_M_X64))
+#if UINTPTR_MAX > 0xfffffffful
     int type;  /* order is here important */
     int ref_count;
 #else

--- a/src/wavesynth/cst_units.c
+++ b/src/wavesynth/cst_units.c
@@ -590,7 +590,7 @@ void add_residual_pulse(int targ_size, unsigned char *targ_residual,
 			int unit_size, const unsigned char *unit_residual)
 {
     int i,m;
-#if (defined(__x86_64__) || defined(_M_X64))
+#if UINTPTR_MAX > 0xfffffffful
     long long p;
     /* Unit residual isn't a pointer its a number, the power for the 
        the sts, yes this is hackily casting the address to a number */


### PR DESCRIPTION
Checking for 64bit systems can be made portably by checking the value of
UINTPTR_MAX. Also, there are 64bit bigendian systems out there :)