### PR TITLE
doc: fix include in example

### DIFF
--- a/doc/flite.texi
+++ b/doc/flite.texi
@@ -812,7 +812,7 @@ distribution, the example diphone voice is @code{cmu_us_kal}.
 
 Here is a simple C program that uses the flite library
 @example
-#include "flite.h"
+#include <flite/flite.h>
 
 cst_voice * register_cmu_us_kal(const char *voxdir);
 


### PR DESCRIPTION
flite.h gets installed in $prefix/include/flite/flite.h, so applications
need to include <flite/flite.h>, not "flite.h".