### PR TITLE
Fix writing missing coefficient

### DIFF
--- a/tools/make_cg.scm
+++ b/tools/make_cg.scm
@@ -315,7 +315,7 @@ Convert a festvox cg voice into a C file."
          (while (< n 5)
             (format ofd "const double %s_me_filter_%d[] = {\n" name n)
             (set! o 0)
-            (while (< o 46)
+            (while (< o 47)
                (format ofd "%f, " (track.get me_filter_track n o))
                (set! o (+ o 1)))
             (format ofd "%f\n};\n" (track.get me_filter_track n o))


### PR DESCRIPTION
There are 48 coefficients. This while loop should write the first 47 (indices [0...46]) and the final coefficient is written after the while statement.