### PR TITLE
Prevent empty segments from being added for syllable breaks

### DIFF
--- a/src/synth/cst_synth.c
+++ b/src/synth/cst_synth.c
@@ -618,7 +618,6 @@ static cst_utterance *tokentosegs(cst_utterance *u)
     sssyl = sylitem = worditem = sylstructureitem = 0;
     for (t = relation_head(utt_relation(u, "Token")); t; t = item_next(t)) 
     {
-	cst_item *segitem = relation_append(seg, NULL);
 	char const *pname = item_feat_string(t, "name");
 	char *name = cst_strdup(pname);
 
@@ -656,6 +655,7 @@ static cst_utterance *tokentosegs(cst_utterance *u)
 	}
 	else
 	{
+	    cst_item *segitem = relation_append(seg, NULL);
 	    item_add_daughter(sssyl,segitem);
 	    item_set_string(segitem, "name", name);
 	}


### PR DESCRIPTION
The -p argument to input phones is meant to allow using '-' to indicate syllable breaks. Right now, this always fails with this error message:

```
> .\flite -p "pau ih0 - n k r ax0 - m eh1 n t - ax0 l pau"
VAL: tried to access string in -1 typed val
```

The problem is that tokentosegs unconditionally adds a new segment to the utterance for every token. In the case of '-', this segment never has its name set and is never added to the syllable structure, which breaks some assumptions later on. Moving the relation_append call past the check for '-' solves the problem.