### PR TITLE
common_make_rules: use $(AR) instead of the native ar command

### DIFF
--- a/config/common_make_rules
+++ b/config/common_make_rules
@@ -122,7 +122,7 @@ $(LIBDIR)/%.so: $(LIBDIR)/%.shared.a
 	@ echo making $@
 	@ rm -rf shared_os && mkdir shared_os
 	@ rm -f $@ $@.${PROJECT_VERSION} $@.${PROJECT_SHLIB_VERSION} 
-	@ (cd shared_os && ar x ../$<)
+	@ (cd shared_os && $(AR) x ../$<)
 	@ (cd shared_os && $(CC) -shared -Wl,-soname,`basename $@`.${PROJECT_SHLIB_VERSION} -o ../$@.${PROJECT_VERSION} *.os $(LDFLAGS))
 	@ (cd $(LIBDIR) && ln -s `basename $@.${PROJECT_VERSION}` `basename $@.${PROJECT_SHLIB_VERSION}` )
 	@ (cd $(LIBDIR) && ln -s `basename $@.${PROJECT_SHLIB_VERSION}` `basename $@` )


### PR DESCRIPTION
I was trying to cross compile this for aarch64, but hit a bump in the road. I got an error that the `ar` command could not be found. This patch ensures that the correct `ar` is used when cross-compiling.

Tested cross compilation by applying this patch in nixpkgs and doing a build with `nix build .#pkgsCross.aarch64-multiplatform.flite`. I've not tried if the binary actually does much, but at least it fully compiles now.

The native binary still works fine, but shouldn't be affected by this change anyway.
