### PR TITLE
make shared arrays size declarations consistent

### DIFF
--- a/lang/cmu_grapheme_lex/cmu_grapheme_lex.h
+++ b/lang/cmu_grapheme_lex/cmu_grapheme_lex.h
@@ -44,7 +44,7 @@ extern "C" {
 cst_lexicon *cmu_grapheme_lex_init(void);
 
 extern const int num_unicode_sampa_mapping;
-extern const char * const unicode_sampa_mapping[16663][5];
+extern const char * const unicode_sampa_mapping[16798][5];
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/lang/cmulex/cmu_lex.c
+++ b/lang/cmulex/cmu_lex.c
@@ -46,7 +46,7 @@ extern const int cmu_lex_entry[];
 extern const unsigned char cmu_lex_data[];
 extern const int cmu_lex_num_entries;
 extern const int cmu_lex_num_bytes;
-extern const char * const cmu_lex_phone_table[54];
+extern const char * const cmu_lex_phone_table[57];
 extern const char * const cmu_lex_phones_huff_table[];
 extern const char * const cmu_lex_entries_huff_table[];
 


### PR DESCRIPTION
Fixes #65 . I have no idea which of the declared sizes are correct, so I went with the larger ones.