### PR TITLE
fix: fix double free bug

### DIFF
--- a/src/audio/audio.c
+++ b/src/audio/audio.c
@@ -183,7 +183,6 @@ int audio_write(cst_audiodev *ad,void *buff,int num_bytes)
 	{
 	    cst_errmsg("audio_write: unknown format conversion (%d => %d) requested.\n",
 		       ad->fmt, ad->real_fmt);
-	    cst_free(nbuf);
 	    if (abuf != buff)
 		cst_free(abuf);
 	    cst_error();


### PR DESCRIPTION
if (ad->real_fmt != ad->fmt) and the control flow enter the "else" branch at line 182, nbuf == abuf, this will cause double free bug.