### PR TITLE
W32: prevent "dllexport" from being added to globalvardefs when building for static linking

### DIFF
--- a/include/flite.h
+++ b/include/flite.h
@@ -65,11 +65,15 @@ extern "C" {
 #include "cst_units.h"
 #include "cst_tokenstream.h"
 
+#ifdef FLITE_STATIC
+#define GLOBALVARDEF
+#else
 #ifdef WIN32
 /* For Visual Studio 2012 global variable definitions */
 #define GLOBALVARDEF __declspec(dllexport)
 #else
 #define GLOBALVARDEF
+#endif
 #endif
  extern GLOBALVARDEF cst_val *flite_voice_list;
  extern GLOBALVARDEF cst_lang flite_lang_list[20];

--- a/src/synth/flite.c
+++ b/src/synth/flite.c
@@ -44,11 +44,15 @@
 #include "cst_clunits.h"
 #include "cst_cg.h"
 
+#ifdef FLITE_STATIC
+#define GLOBALVARDEF
+#else
 #ifdef WIN32
 /* For Visual Studio 2012 global variable definitions */
 #define GLOBALVARDEF __declspec(dllexport)
 #else
 #define GLOBALVARDEF
+#endif
 #endif
 
 /* This is a global, which isn't ideal, this may change */


### PR DESCRIPTION
This PR introduces an `FLITE_STATIC` define.

If `FLITE_STATIC` is defined at build-time, `GLOBALVARDEF` decorator will not use `__declspec(dllexport)` (on Windows).
This allows using a static flite on Windows (other platforms don't have this problem).

The `FLITE_STATIC` define must be set manually by whoever wants to use flite in this way.


Closes: https://github.com/festvox/flite/issues/83

