### PR TITLE
Fix compatibility with texinfo 7

### DIFF
--- a/doc/Makefile
+++ b/doc/Makefile
@@ -50,7 +50,7 @@ doc: flite.html flite.pdf
 flite.html: flite.texi
 	@ if [ ! -d html ] ; \
           then mkdir -p html ; fi
-	(cd html; texi2any --set-customization-variable TEXI2HTML=1  --split=chapter ../flite.texi)
+	(cd html; texi2any --set-customization-variable TEXI2HTML=1 --output=flite --split=chapter ../flite.texi)
 	@ if [ -d html/flite ] ; \
 	  then mv html/flite/*.html html ; \
                rmdir html/flite; fi


### PR DESCRIPTION
Because of this change:

7.0 (7 November 2022)
* texi2any . HTML output: . use manual_name_html as output directory for split HTML instead of manual_name or manual_name.html